### PR TITLE
♻️ REFAC: resolve all clippy warnings

### DIFF
--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -5,6 +5,7 @@ use crate::models::package::Package;
 ///
 /// Returns a new vector with excluded packages filtered out.
 #[must_use]
+#[allow(dead_code)]
 pub fn apply_permanent_excludes(packages: Vec<Package>, config: &Config) -> Vec<Package> {
     let excludes = &config.exclude.permanent;
     packages
@@ -17,6 +18,7 @@ pub fn apply_permanent_excludes(packages: Vec<Package>, config: &Config) -> Vec<
 ///
 /// Returns a new vector with excluded packages filtered out.
 #[must_use]
+#[allow(dead_code)]
 pub fn apply_temporary_excludes(packages: Vec<Package>, temp_excludes: &[String]) -> Vec<Package> {
     packages
         .into_iter()

--- a/src/core/planner.rs
+++ b/src/core/planner.rs
@@ -9,6 +9,7 @@ pub enum UpdateMode {
 
 pub struct UpdatePlan {
     pub mode: UpdateMode,
+    #[allow(dead_code)]
     pub packages: Vec<Package>,
     pub ignore_list: Vec<String>,
 }

--- a/src/io/command.rs
+++ b/src/io/command.rs
@@ -5,8 +5,20 @@ use std::time::Duration;
 #[derive(Debug)]
 pub enum CommandError {
     ExecutionFailed(String),
+    #[allow(dead_code)]
     NotFound(String),
 }
+
+impl std::fmt::Display for CommandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ExecutionFailed(msg) => write!(f, "Command execution failed: {msg}"),
+            Self::NotFound(msg) => write!(f, "Command not found: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for CommandError {}
 
 /// Runs `checkupdates` to scan for official package updates with retry logic.
 ///
@@ -57,6 +69,7 @@ where
 ///
 /// Returns `CommandError::ExecutionFailed` if the command fails to execute
 /// or returns a non-zero exit status after all retries (except exit code 2, which means no updates).
+#[allow(dead_code)]
 pub fn run_checkupdates() -> Result<String, CommandError> {
     run_checkupdates_with_callback(|_, _| {})
 }

--- a/src/io/file.rs
+++ b/src/io/file.rs
@@ -2,11 +2,24 @@ use std::fs;
 use std::path::Path;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum FileError {
     ReadFailed(String),
     WriteFailed(String),
     NotFound,
 }
+
+impl std::fmt::Display for FileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReadFailed(msg) => write!(f, "Failed to read file: {msg}"),
+            Self::WriteFailed(msg) => write!(f, "Failed to write file: {msg}"),
+            Self::NotFound => write!(f, "File not found"),
+        }
+    }
+}
+
+impl std::error::Error for FileError {}
 
 /// Reads configuration file from the given path.
 ///

--- a/src/io/terminal.rs
+++ b/src/io/terminal.rs
@@ -99,8 +99,7 @@ fn start_scan_thread(
         let tx_clone = tx.clone();
         match command::run_checkupdates_with_callback(|attempt, max| {
             let _ = tx_clone.send(ScanMessage::Progress(format!(
-                "Retrying checkupdates (attempt {}/{})",
-                attempt, max
+                "Retrying checkupdates (attempt {attempt}/{max})"
             )));
         }) {
             Ok(output) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,10 +21,7 @@ fn main() {
     let config_path = PathBuf::from(config_home).join("partui/config.toml");
 
     let config = if let Ok(content) = file::read_config(&config_path) {
-        match toml_parser::parse_config(&content) {
-            Ok(cfg) => cfg,
-            Err(_) => models::config::Config::default(),
-        }
+        toml_parser::parse_config(&content).unwrap_or_default()
     } else {
         models::config::Config::default()
     };

--- a/src/parser/toml.rs
+++ b/src/parser/toml.rs
@@ -1,9 +1,20 @@
 use crate::models::config::Config;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum ParseError {
     InvalidToml(String),
 }
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidToml(msg) => write!(f, "Invalid TOML: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
 
 /// Parses TOML configuration content into a Config struct.
 ///

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -8,6 +8,7 @@ pub enum UIEvent {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
 pub enum LoadingState {
     Scanning,
     Ready,
@@ -47,6 +48,7 @@ impl AppState {
 
     /// Creates a new `AppState` with the given packages and permanent exclusions.
     #[must_use]
+    #[allow(dead_code)]
     pub fn new(packages: Vec<Package>, permanent_excludes: &[String]) -> Self {
         let items = Self::create_package_items(packages, permanent_excludes);
 
@@ -73,7 +75,7 @@ impl AppState {
         self.loading_state = LoadingState::Ready;
     }
 
-    /// Helper to create PackageItem list from packages and permanent exclusions
+    /// Helper to create `PackageItem` list from packages and permanent exclusions
     fn create_package_items(
         packages: Vec<Package>,
         permanent_excludes: &[String],
@@ -95,6 +97,7 @@ impl AppState {
         self.loading_state = LoadingState::NoUpdates;
     }
 
+    #[allow(dead_code)]
     pub fn set_error<S: Into<String>>(&mut self, error: S) {
         self.loading_state = LoadingState::Error(error.into());
     }

--- a/src/ui/view.rs
+++ b/src/ui/view.rs
@@ -242,9 +242,7 @@ fn render_package_list(frame: &mut Frame, area: Rect, state: &AppState) {
     let total_items = state.packages.len();
 
     // Calculate offset to keep cursor visible
-    let offset = if total_items <= visible_height {
-        0
-    } else if state.cursor_position < visible_height / 2 {
+    let offset = if total_items <= visible_height || state.cursor_position < visible_height / 2 {
         0
     } else if state.cursor_position >= total_items - visible_height / 2 {
         total_items.saturating_sub(visible_height)

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1,4 +1,4 @@
-use par_tui::models::package::{Package, PackageRepository};
+use par_tui::models::package::PackageRepository;
 use par_tui::parser::pacman;
 
 #[test]
@@ -15,10 +15,10 @@ fn test_parse_checkupdates_single_package() {
 
 #[test]
 fn test_parse_checkupdates_multiple_packages() {
-    let output = r#"linux 6.1.10-1 -> 6.1.12-1
+    let output = r"linux 6.1.10-1 -> 6.1.12-1
 mesa 23.0.1-1 -> 23.0.2-1
 systemd 253.1-1 -> 253.2-1
-"#;
+";
     let packages = pacman::parse_checkupdates_output(output);
 
     assert_eq!(packages.len(), 3);
@@ -37,10 +37,10 @@ fn test_parse_checkupdates_empty() {
 
 #[test]
 fn test_parse_checkupdates_malformed_line() {
-    let output = r#"linux 6.1.10-1 -> 6.1.12-1
+    let output = r"linux 6.1.10-1 -> 6.1.12-1
 invalid line
 mesa 23.0.1-1 -> 23.0.2-1
-"#;
+";
     let packages = pacman::parse_checkupdates_output(output);
 
     // Should skip malformed line


### PR DESCRIPTION
## Summary
Resolves all clippy warnings in the codebase while maintaining future-use code.

## Changes
- Fixed identical if blocks in view.rs scroll offset calculation
- Added Display/Error trait implementations for all error types (CommandError, FileError, ParseError)
- Added allow(dead_code) for future-use functions and variants

## Verification
- All clippy warnings resolved
- All tests passing
- Code formatted

## Type
Refactoring - no behavior changes