### PR TITLE
✨ FEAT: Add dependency conflict detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+REVIEW*.md

--- a/src/core/dependency.rs
+++ b/src/core/dependency.rs
@@ -3,7 +3,6 @@ use std::collections::HashSet;
 
 /// Represents a dependency conflict warning.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
 pub struct DependencyConflict {
     pub ignored_package: String,
     pub required_by: Vec<String>,

--- a/src/core/dependency.rs
+++ b/src/core/dependency.rs
@@ -88,13 +88,14 @@ where
         let required_by = get_required_by(ignored);
 
         // Find conflicts: packages that are being updated and require this ignored package
-        let conflicting: Vec<String> = required_by
+        let mut conflicting: Vec<String> = required_by
             .iter()
             .filter(|dep| updating_packages.contains(dep.as_str()))
             .cloned()
             .collect();
 
         if !conflicting.is_empty() {
+            conflicting.sort();
             conflicts.push(DependencyConflict {
                 ignored_package: ignored.clone(),
                 required_by: conflicting,
@@ -102,6 +103,7 @@ where
         }
     }
 
+    conflicts.sort_by(|a, b| a.ignored_package.cmp(&b.ignored_package));
     conflicts
 }
 

--- a/src/core/dependency.rs
+++ b/src/core/dependency.rs
@@ -1,0 +1,157 @@
+use crate::models::package::Package;
+use std::collections::{HashMap, HashSet};
+
+/// Represents a dependency conflict warning.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct DependencyConflict {
+    pub ignored_package: String,
+    pub required_by: Vec<String>,
+}
+
+/// Detects dependency conflicts when packages are ignored.
+///
+/// Checks if any packages being updated depend on packages being ignored.
+/// This prevents partial upgrade scenarios that could break the system.
+///
+/// # Arguments
+///
+/// * `all_packages` - All packages available for update
+/// * `ignored_packages` - Package names being ignored (temporary or permanent)
+/// * `get_required_by` - Function to fetch reverse dependencies for a package
+///
+/// # Returns
+///
+/// Vector of conflicts, where ignored packages are required by packages being updated.
+#[allow(dead_code)]
+pub fn detect_conflicts<F>(
+    all_packages: &[Package],
+    ignored_packages: &[String],
+    mut get_required_by: F,
+) -> Vec<DependencyConflict>
+where
+    F: FnMut(&str) -> Vec<String>,
+{
+    let ignored_set: HashSet<&str> = ignored_packages.iter().map(String::as_str).collect();
+    let updating_packages: HashSet<&str> = all_packages
+        .iter()
+        .map(|p| p.name.as_str())
+        .filter(|name| !ignored_set.contains(name))
+        .collect();
+
+    let mut conflicts = Vec::new();
+    let mut cache: HashMap<String, Vec<String>> = HashMap::new();
+
+    for ignored in ignored_packages {
+        // Get or fetch reverse dependencies
+        let required_by = cache
+            .entry(ignored.clone())
+            .or_insert_with(|| get_required_by(ignored))
+            .clone();
+
+        // Find conflicts: packages that are being updated and require this ignored package
+        let conflicting: Vec<String> = required_by
+            .iter()
+            .filter(|dep| updating_packages.contains(dep.as_str()))
+            .cloned()
+            .collect();
+
+        if !conflicting.is_empty() {
+            conflicts.push(DependencyConflict {
+                ignored_package: ignored.clone(),
+                required_by: conflicting,
+            });
+        }
+    }
+
+    conflicts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::package::PackageRepository;
+
+    fn make_package(name: &str) -> Package {
+        Package {
+            name: name.to_string(),
+            current_version: Some("1.0.0".to_string()),
+            new_version: "2.0.0".to_string(),
+            repository: PackageRepository::Official,
+        }
+    }
+
+    #[test]
+    fn test_no_conflicts() {
+        let packages = vec![make_package("pkg1"), make_package("pkg2")];
+        let ignored = vec!["pkg3".to_string()];
+
+        let conflicts = detect_conflicts(&packages, &ignored, |_| Vec::new());
+
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_conflict_detected() {
+        let packages = vec![
+            make_package("pkg1"),
+            make_package("pkg2"),
+            make_package("pkg3"),
+        ];
+        let ignored = vec!["pkg2".to_string()];
+
+        let get_deps = |name: &str| -> Vec<String> {
+            match name {
+                "pkg2" => vec!["pkg1".to_string(), "pkg3".to_string()],
+                _ => Vec::new(),
+            }
+        };
+
+        let conflicts = detect_conflicts(&packages, &ignored, get_deps);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].ignored_package, "pkg2");
+        assert_eq!(conflicts[0].required_by.len(), 2);
+        assert!(conflicts[0].required_by.contains(&"pkg1".to_string()));
+        assert!(conflicts[0].required_by.contains(&"pkg3".to_string()));
+    }
+
+    #[test]
+    fn test_ignored_package_not_required() {
+        let packages = vec![make_package("pkg1"), make_package("pkg2")];
+        let ignored = vec!["pkg3".to_string()];
+
+        let get_deps = |name: &str| -> Vec<String> {
+            match name {
+                "pkg3" => vec!["pkg4".to_string(), "pkg5".to_string()],
+                _ => Vec::new(),
+            }
+        };
+
+        let conflicts = detect_conflicts(&packages, &ignored, get_deps);
+
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_multiple_conflicts() {
+        let packages = vec![
+            make_package("pkg1"),
+            make_package("pkg2"),
+            make_package("pkg3"),
+        ];
+        let ignored = vec!["base".to_string(), "glibc".to_string()];
+
+        let get_deps = |name: &str| -> Vec<String> {
+            match name {
+                "base" => vec!["pkg1".to_string()],
+                "glibc" => vec!["pkg2".to_string(), "pkg3".to_string()],
+                _ => Vec::new(),
+            }
+        };
+
+        let conflicts = detect_conflicts(&packages, &ignored, get_deps);
+
+        assert_eq!(conflicts.len(), 2);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,2 +1,3 @@
+pub mod dependency;
 pub mod filter;
 pub mod planner;

--- a/src/io/command.rs
+++ b/src/io/command.rs
@@ -104,3 +104,26 @@ pub fn check_command_exists(command: &str) -> bool {
         .map(|output| output.status.success())
         .unwrap_or(false)
 }
+
+/// Gets the list of packages that depend on the specified package.
+///
+/// Uses `pacman -Qi <package>` to retrieve the "Required By" field.
+///
+/// # Errors
+///
+/// Returns `CommandError::ExecutionFailed` if the command fails or package is not found.
+#[allow(dead_code)]
+pub fn get_package_required_by(package: &str) -> Result<String, CommandError> {
+    let output = Command::new("pacman")
+        .args(["-Qi", package])
+        .output()
+        .map_err(|e| CommandError::ExecutionFailed(e.to_string()))?;
+
+    if !output.status.success() {
+        return Err(CommandError::ExecutionFailed(format!(
+            "Package '{package}' not found"
+        )));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}

--- a/src/io/command.rs
+++ b/src/io/command.rs
@@ -112,7 +112,6 @@ pub fn check_command_exists(command: &str) -> bool {
 /// # Errors
 ///
 /// Returns `CommandError::ExecutionFailed` if the command fails or package is not found.
-#[allow(dead_code)]
 pub fn get_package_required_by(package: &str) -> Result<String, CommandError> {
     let output = Command::new("pacman")
         .args(["-Qi", package])

--- a/src/io/terminal.rs
+++ b/src/io/terminal.rs
@@ -13,9 +13,9 @@ use std::sync::{
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use crate::io::command;
 use crate::models::config::Config;
 use crate::models::package::Package;
-use crate::io::command;
 use crate::parser::{pacman, paru};
 use crate::ui::{
     app::{AppState, LoadingState, UIEvent},

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod ui;
 
 use core::planner::{self, UpdateMode};
 use io::{command, file, terminal};
-use parser::toml as toml_parser;
+use parser::{pacman, toml as toml_parser};
 use std::path::PathBuf;
 use ui::app::UIEvent;
 
@@ -41,7 +41,7 @@ fn main() {
             Ok((Some(UIEvent::Reload), _)) => {
                 // Reload: restart scan, do not save config
             },
-            Ok((Some(event), final_state)) => {
+            Ok((Some(event), mut final_state)) => {
                 // Terminating event: save config if changed, then execute
                 // Skip saving if state is not ready (e.g., quit during scan)
                 if final_state.is_ready() {
@@ -58,15 +58,59 @@ fn main() {
                 match event {
                     UIEvent::UpdateEntireSystem => {
                         let ignored = final_state.get_ignored_packages();
-                        execute_update(UpdateMode::EntireSystem, all_packages, ignored, &config);
+
+                        // Check dependencies before executing
+                        match check_and_confirm_dependencies(
+                            &mut final_state,
+                            &all_packages,
+                            &ignored,
+                        ) {
+                            Ok(true) => {
+                                execute_update(
+                                    UpdateMode::EntireSystem,
+                                    all_packages,
+                                    ignored,
+                                    &config,
+                                );
+                            },
+                            Ok(false) => {
+                                // User cancelled, do nothing
+                            },
+                            Err(e) => {
+                                eprintln!("Failed to check dependencies: {e}");
+                            },
+                        }
                     },
                     UIEvent::UpdateOfficialOnly => {
                         let ignored = final_state.get_ignored_packages();
-                        execute_update(UpdateMode::OfficialOnly, all_packages, ignored, &config);
+
+                        // Check dependencies before executing
+                        match check_and_confirm_dependencies(
+                            &mut final_state,
+                            &all_packages,
+                            &ignored,
+                        ) {
+                            Ok(true) => {
+                                execute_update(
+                                    UpdateMode::OfficialOnly,
+                                    all_packages,
+                                    ignored,
+                                    &config,
+                                );
+                            },
+                            Ok(false) => {
+                                // User cancelled, do nothing
+                            },
+                            Err(e) => {
+                                eprintln!("Failed to check dependencies: {e}");
+                            },
+                        }
                     },
                     UIEvent::Quit => {},
                     UIEvent::Reload => {
-                        panic!("DESIGN VIOLATION: UIEvent::Reload must be handled by the outer loop (Ok((Some(UIEvent::Reload), _)))")
+                        panic!(
+                            "DESIGN VIOLATION: UIEvent::Reload must be handled by the outer loop (Ok((Some(UIEvent::Reload), _)))"
+                        )
                     },
                 }
                 break;
@@ -101,6 +145,44 @@ fn save_config_if_changed(
                 eprintln!("Warning: Could not serialize config: {e:?}");
             },
         }
+    }
+}
+
+fn check_and_confirm_dependencies(
+    state: &mut ui::app::AppState,
+    all_packages: &[models::package::Package],
+    ignored: &[String],
+) -> std::io::Result<bool> {
+    // Perform dependency check (orchestration: main.rs calls core and parser)
+    match core::dependency::check_conflicts(all_packages, ignored, |pkg| {
+        state.get_or_fetch_required_by(pkg, || {
+            command::get_package_required_by(pkg)
+                .map(|output| pacman::parse_required_by(&output))
+                .map_err(|e| e.to_string())
+        })
+    }) {
+        Ok(conflicts) => {
+            if conflicts.is_empty() {
+                // No conflicts, proceed
+                return Ok(true);
+            }
+
+            // Conflicts found, show modal for user decision
+            state.set_dependency_conflicts(conflicts);
+            state.show_dependency_warning = true;
+
+            // Re-enter TUI for confirmation
+            match terminal::run_tui_for_confirmation(state)? {
+                Some(UIEvent::UpdateEntireSystem | UIEvent::UpdateOfficialOnly) => Ok(true),
+                _ => Ok(false), // User cancelled or quit
+            }
+        },
+        Err(warnings) => {
+            for warning in warnings {
+                eprintln!("Dependency check warning: {warning}");
+            }
+            Ok(false) // Don't proceed if dependency check failed
+        },
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,10 @@ fn main() {
             },
             Ok((Some(event), final_state)) => {
                 // Terminating event: save config if changed, then execute
-                save_config_if_changed(&config_path, &config, &final_state);
+                // Skip saving if state is not ready (e.g., quit during scan)
+                if final_state.is_ready() {
+                    save_config_if_changed(&config_path, &config, &final_state);
+                }
 
                 // Get all packages from final state
                 let all_packages: Vec<models::package::Package> = final_state

--- a/src/parser/pacman.rs
+++ b/src/parser/pacman.rs
@@ -42,10 +42,7 @@ pub fn parse_required_by(output: &str) -> Vec<String> {
             if value == "None" || value.is_empty() {
                 return Vec::new();
             }
-            return value
-                .split_whitespace()
-                .map(String::from)
-                .collect();
+            return value.split_whitespace().map(String::from).collect();
         }
     }
     Vec::new()

--- a/src/parser/pacman.rs
+++ b/src/parser/pacman.rs
@@ -22,3 +22,31 @@ pub fn parse_checkupdates_output(output: &str) -> Vec<Package> {
         })
         .collect()
 }
+
+/// Parses `pacman -Qi` output to extract the "Required By" field.
+///
+/// Expected format:
+/// ```text
+/// Required By     : pkg1  pkg2  pkg3
+/// ```
+///
+/// Returns a vector of package names that depend on the queried package.
+/// Returns empty vector if "Required By" field is "None" or not found.
+#[must_use]
+#[allow(dead_code)]
+pub fn parse_required_by(output: &str) -> Vec<String> {
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if let Some(value) = trimmed.strip_prefix("Required By") {
+            let value = value.trim().trim_start_matches(':').trim();
+            if value == "None" || value.is_empty() {
+                return Vec::new();
+            }
+            return value
+                .split_whitespace()
+                .map(String::from)
+                .collect();
+        }
+    }
+    Vec::new()
+}

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -209,6 +209,15 @@ impl AppState {
             .any(|w| w.contains(crate::io::terminal::OFFICIAL_SCAN_FAILURE_MARKER))
     }
 
+    /// Returns true if state is ready (not loading/scanning)
+    #[must_use]
+    pub fn is_ready(&self) -> bool {
+        matches!(
+            self.loading_state,
+            LoadingState::Ready | LoadingState::NoUpdates
+        )
+    }
+
     /// Toggles dependency warning modal visibility
     pub fn toggle_dependency_warning(&mut self) {
         self.show_dependency_warning = !self.show_dependency_warning;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -145,6 +145,8 @@ impl AppState {
             && !item.is_permanently_ignored
         {
             item.is_temporarily_ignored = !item.is_temporarily_ignored;
+            // Clear cache as ignore status affects conflict detection
+            self.reverse_deps_cache.clear();
         }
     }
 
@@ -154,6 +156,8 @@ impl AppState {
             if item.is_permanently_ignored {
                 item.is_temporarily_ignored = false;
             }
+            // Clear cache as ignore status affects conflict detection
+            self.reverse_deps_cache.clear();
         }
     }
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1,4 +1,5 @@
 use crate::models::package::Package;
+use crate::core::dependency::DependencyConflict;
 
 #[derive(Debug, Clone)]
 pub enum UIEvent {
@@ -24,6 +25,9 @@ pub struct AppState {
     pub loading_state: LoadingState,
     pub loading_message: String,
     pub scan_warnings: Vec<String>,
+    pub dependency_conflicts: Vec<DependencyConflict>,
+    pub show_dependency_warning: bool,
+    pub pending_action: Option<UIEvent>,
 }
 
 #[derive(Debug, Clone)]
@@ -44,6 +48,9 @@ impl AppState {
             loading_state: LoadingState::Scanning,
             loading_message: "Initializing...".to_string(),
             scan_warnings: Vec::new(),
+            dependency_conflicts: Vec::new(),
+            show_dependency_warning: false,
+            pending_action: None,
         }
     }
 
@@ -60,6 +67,9 @@ impl AppState {
             loading_state: LoadingState::Ready,
             loading_message: String::new(),
             scan_warnings: Vec::new(),
+            dependency_conflicts: Vec::new(),
+            show_dependency_warning: false,
+            pending_action: None,
         }
     }
 
@@ -184,5 +194,25 @@ impl AppState {
         self.scan_warnings
             .iter()
             .any(|w| w.contains(crate::io::terminal::OFFICIAL_SCAN_FAILURE_MARKER))
+    }
+
+    /// Toggles dependency warning modal visibility
+    pub fn toggle_dependency_warning(&mut self) {
+        self.show_dependency_warning = !self.show_dependency_warning;
+    }
+
+    /// Sets dependency conflicts and shows warning modal
+    pub fn set_dependency_conflicts(&mut self, conflicts: Vec<DependencyConflict>) {
+        self.dependency_conflicts = conflicts;
+        if !self.dependency_conflicts.is_empty() {
+            self.show_dependency_warning = true;
+        }
+    }
+
+    /// Checks if there are any dependency conflicts
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn has_conflicts(&self) -> bool {
+        !self.dependency_conflicts.is_empty()
     }
 }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -28,7 +28,16 @@ pub struct AppState {
     pub scan_warnings: Vec<String>,
     pub dependency_conflicts: Vec<DependencyConflict>,
     pub show_dependency_warning: bool,
+    
+    /// Pending action lifecycle:
+    /// 1. Set when Enter/o pressed (before dependency check)
+    /// 2. Held during dependency warning modal display
+    /// 3. Consumed (`take()`) when user confirms (y)
+    /// 4. Cleared (None) when user cancels (n/Esc)
     pub pending_action: Option<UIEvent>,
+    
+    /// Cache for `pacman -Qi` reverse dependency queries
+    /// Key: package name, Value: list of packages requiring it
     pub reverse_deps_cache: HashMap<String, Vec<String>>,
 }
 

--- a/src/ui/view.rs
+++ b/src/ui/view.rs
@@ -391,9 +391,8 @@ fn render_dependency_warning_modal(frame: &mut Frame, state: &AppState) {
         u16::try_from(total_lines).unwrap_or(max_height.saturating_mul(80).saturating_div(100));
     let required_height = content_height.saturating_add(chrome_height);
 
-    let height_percent = required_height
-        .saturating_mul(100)
-        .checked_div(max_height)
+    let height_percent = ((u32::from(required_height) * 100) / u32::from(max_height))
+        .try_into()
         .unwrap_or(80)
         .clamp(40, 80);
 

--- a/src/ui/view.rs
+++ b/src/ui/view.rs
@@ -368,22 +368,22 @@ fn render_help_modal(frame: &mut Frame) {
 
 fn render_dependency_warning_modal(frame: &mut Frame, state: &AppState) {
     // Calculate required height based on content
-    let header_lines = 5; // Title + description
-    let footer_lines = 4; // Warning message + keybinds
+    let header_lines = 5; // Empty + title + empty + description + empty
+    let footer_lines = 4; // Empty + warning + empty + keybinds
     
     let mut content_lines = 0;
     for conflict in &state.dependency_conflicts {
-        content_lines += 1; // Package name line
-        content_lines += conflict.required_by.len(); // Dependency lines
-        content_lines += 1; // Blank line
+        content_lines += 1; // Package name line ("• pkg is required by:")
+        content_lines += conflict.required_by.len(); // Each "→ dep" line
+        content_lines += 1; // Blank line separator
     }
     
     let total_lines = header_lines + content_lines + footer_lines;
     
     // Calculate dynamic size (minimum 40%, maximum 80% of screen height)
-    let max_height = frame.area().height;
+    let max_height = frame.area().height.max(1); // Prevent division by zero
     let required_height = u16::try_from(total_lines + 4).unwrap_or(u16::MAX); // +4 for borders and padding
-    let height_percent = (required_height * 100 / max_height).clamp(40, 80);
+    let height_percent = ((required_height * 100) / max_height).clamp(40, 80);
     
     let area = centered_rect(70, height_percent, frame.area());
 
@@ -443,7 +443,9 @@ fn render_dependency_warning_modal(frame: &mut Frame, state: &AppState) {
         ]),
     ]);
 
-    // Use Paragraph with wrap for automatic scrolling if content is too long
+    // Use Paragraph with wrap to handle long lines gracefully
+    // Note: If content exceeds modal height, bottom lines will be cut off.
+    // True scrolling would require additional state management.
     let warning = Paragraph::new(warning_lines)
         .block(
             Block::default()

--- a/src/ui/view.rs
+++ b/src/ui/view.rs
@@ -367,7 +367,25 @@ fn render_help_modal(frame: &mut Frame) {
 }
 
 fn render_dependency_warning_modal(frame: &mut Frame, state: &AppState) {
-    let area = centered_rect(70, 60, frame.area());
+    // Calculate required height based on content
+    let header_lines = 5; // Title + description
+    let footer_lines = 4; // Warning message + keybinds
+    
+    let mut content_lines = 0;
+    for conflict in &state.dependency_conflicts {
+        content_lines += 1; // Package name line
+        content_lines += conflict.required_by.len(); // Dependency lines
+        content_lines += 1; // Blank line
+    }
+    
+    let total_lines = header_lines + content_lines + footer_lines;
+    
+    // Calculate dynamic size (minimum 40%, maximum 80% of screen height)
+    let max_height = frame.area().height;
+    let required_height = u16::try_from(total_lines + 4).unwrap_or(u16::MAX); // +4 for borders and padding
+    let height_percent = (required_height * 100 / max_height).clamp(40, 80);
+    
+    let area = centered_rect(70, height_percent, frame.area());
 
     let mut warning_lines = vec![
         Line::from(""),
@@ -425,6 +443,7 @@ fn render_dependency_warning_modal(frame: &mut Frame, state: &AppState) {
         ]),
     ]);
 
+    // Use Paragraph with wrap for automatic scrolling if content is too long
     let warning = Paragraph::new(warning_lines)
         .block(
             Block::default()
@@ -433,7 +452,8 @@ fn render_dependency_warning_modal(frame: &mut Frame, state: &AppState) {
                 .border_style(Style::default().fg(Color::Red))
                 .style(Style::default().bg(Color::Black)),
         )
-        .alignment(Alignment::Left);
+        .alignment(Alignment::Left)
+        .wrap(ratatui::widgets::Wrap { trim: false });
 
     frame.render_widget(Clear, area);
     frame.render_widget(warning, area);

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -48,3 +48,44 @@ mesa 23.0.1-1 -> 23.0.2-1
     assert_eq!(packages[0].name, "linux");
     assert_eq!(packages[1].name, "mesa");
 }
+
+#[test]
+fn test_parse_required_by_none() {
+    let output = r"Name            : test-package
+Version         : 1.0.0-1
+Required By     : None
+";
+    let deps = pacman::parse_required_by(output);
+    assert!(deps.is_empty());
+}
+
+#[test]
+fn test_parse_required_by_single() {
+    let output = r"Name            : bash
+Required By     : base
+";
+    let deps = pacman::parse_required_by(output);
+    assert_eq!(deps.len(), 1);
+    assert_eq!(deps[0], "base");
+}
+
+#[test]
+fn test_parse_required_by_multiple() {
+    let output = r"Name            : glibc
+Required By     : bash  systemd  pacman
+";
+    let deps = pacman::parse_required_by(output);
+    assert_eq!(deps.len(), 3);
+    assert!(deps.contains(&"bash".to_string()));
+    assert!(deps.contains(&"systemd".to_string()));
+    assert!(deps.contains(&"pacman".to_string()));
+}
+
+#[test]
+fn test_parse_required_by_not_found() {
+    let output = r"Name            : test-package
+Version         : 1.0.0-1
+";
+    let deps = pacman::parse_required_by(output);
+    assert!(deps.is_empty());
+}

--- a/tests/ui_tests.rs
+++ b/tests/ui_tests.rs
@@ -382,3 +382,27 @@ fn test_reverse_deps_cache_error_handling() {
     assert_eq!(err2, Some("Still not found".to_string()));
 }
 
+#[test]
+fn test_is_ready_states() {
+    use par_tui::ui::app::LoadingState;
+    
+    let packages = vec![make_test_package("pkg1", PackageRepository::Official)];
+    let mut state = AppState::new(packages, &[]);
+    
+    // Ready state
+    state.loading_state = LoadingState::Ready;
+    assert!(state.is_ready());
+    
+    // NoUpdates state
+    state.loading_state = LoadingState::NoUpdates;
+    assert!(state.is_ready());
+    
+    // Scanning state (not ready)
+    state.loading_state = LoadingState::Scanning;
+    assert!(!state.is_ready());
+    
+    // Error state (not ready)
+    state.loading_state = LoadingState::Error("test".to_string());
+    assert!(!state.is_ready());
+}
+

--- a/tests/ui_tests.rs
+++ b/tests/ui_tests.rs
@@ -249,3 +249,136 @@ fn test_scan_failure_marker_constants() {
     assert_eq!(AUR_SCAN_FAILURE_MARKER, "AUR");
 }
 
+// Phase 2: UI Integration Tests for dependency warnings
+
+#[test]
+fn test_set_dependency_conflicts_shows_modal() {
+    use par_tui::core::dependency::DependencyConflict;
+    
+    let packages = vec![make_test_package("pkg1", PackageRepository::Official)];
+    let mut state = AppState::new(packages, &[]);
+    
+    assert!(!state.show_dependency_warning);
+    
+    let conflicts = vec![DependencyConflict {
+        ignored_package: "glibc".to_string(),
+        required_by: vec!["systemd".to_string()],
+    }];
+    
+    state.set_dependency_conflicts(conflicts);
+    
+    assert!(state.show_dependency_warning);
+    assert_eq!(state.dependency_conflicts.len(), 1);
+}
+
+#[test]
+fn test_toggle_dependency_warning() {
+    let packages = vec![make_test_package("pkg1", PackageRepository::Official)];
+    let mut state = AppState::new(packages, &[]);
+    
+    assert!(!state.show_dependency_warning);
+    
+    state.toggle_dependency_warning();
+    assert!(state.show_dependency_warning);
+    
+    state.toggle_dependency_warning();
+    assert!(!state.show_dependency_warning);
+}
+
+#[test]
+fn test_has_conflicts() {
+    use par_tui::core::dependency::DependencyConflict;
+    
+    let packages = vec![make_test_package("pkg1", PackageRepository::Official)];
+    let mut state = AppState::new(packages, &[]);
+    
+    assert!(!state.has_conflicts());
+    
+    state.dependency_conflicts.push(DependencyConflict {
+        ignored_package: "test".to_string(),
+        required_by: vec!["dep".to_string()],
+    });
+    
+    assert!(state.has_conflicts());
+}
+
+#[test]
+fn test_pending_action_lifecycle() {
+    use par_tui::ui::app::UIEvent;
+    
+    let packages = vec![make_test_package("pkg1", PackageRepository::Official)];
+    let mut state = AppState::new(packages, &[]);
+    
+    // Initially None
+    assert!(state.pending_action.is_none());
+    
+    // Set action
+    state.pending_action = Some(UIEvent::UpdateEntireSystem);
+    assert!(state.pending_action.is_some());
+    
+    // Take consumes it
+    let action = state.pending_action.take();
+    assert!(matches!(action, Some(UIEvent::UpdateEntireSystem)));
+    assert!(state.pending_action.is_none());
+    
+    // Clear sets to None
+    state.pending_action = Some(UIEvent::UpdateOfficialOnly);
+    state.pending_action = None;
+    assert!(state.pending_action.is_none());
+}
+
+#[test]
+fn test_reverse_deps_cache() {
+    let packages = vec![make_test_package("pkg1", PackageRepository::Official)];
+    let mut state = AppState::new(packages, &[]);
+    
+    let mut call_count = 0;
+    
+    // First call: cache miss, fetch called
+    let (deps1, err1) = state.get_or_fetch_required_by("glibc", || {
+        call_count += 1;
+        Ok(vec!["systemd".to_string(), "bash".to_string()])
+    });
+    assert_eq!(call_count, 1);
+    assert_eq!(deps1.len(), 2);
+    assert!(err1.is_none());
+    
+    // Second call: cache hit, fetch not called
+    let (deps2, err2) = state.get_or_fetch_required_by("glibc", || {
+        call_count += 1;
+        Ok(vec![])  // Should not be reached
+    });
+    assert_eq!(call_count, 1); // No increment - cache was used
+    assert_eq!(deps2.len(), 2);
+    assert!(err2.is_none());
+    
+    // Different package: cache miss again
+    let (deps3, err3) = state.get_or_fetch_required_by("bash", || {
+        call_count += 1;
+        Ok(vec!["base".to_string()])
+    });
+    assert_eq!(call_count, 2);
+    assert_eq!(deps3.len(), 1);
+    assert!(err3.is_none());
+}
+
+#[test]
+fn test_reverse_deps_cache_error_handling() {
+    let packages = vec![make_test_package("pkg1", PackageRepository::Official)];
+    let mut state = AppState::new(packages, &[]);
+    
+    // Fetch error: not cached
+    let (deps1, err1) = state.get_or_fetch_required_by("nonexistent", || {
+        Err("Package not found".to_string())
+    });
+    assert!(deps1.is_empty());
+    assert_eq!(err1, Some("Package not found".to_string()));
+    
+    // Error result is not cached: fetch called again
+    let (deps2, err2) = state.get_or_fetch_required_by("nonexistent", || {
+        Err("Still not found".to_string())
+    });
+    assert!(deps2.is_empty());
+    assert_eq!(err2, Some("Still not found".to_string()));
+}
+

--- a/tests/ui_tests.rs
+++ b/tests/ui_tests.rs
@@ -234,7 +234,9 @@ fn test_has_official_scan_failed_with_aur_failure_only() {
 fn test_has_official_scan_failed_with_combined_failure() {
     let packages = vec![make_test_package("pkg1", PackageRepository::Official)];
     let mut state = AppState::new(packages, &[]);
-    state.scan_warnings.push("Official & AUR scan failed".to_string());
+    state
+        .scan_warnings
+        .push("Official & AUR scan failed".to_string());
 
     // Should detect "Official" marker even in combined message
     assert!(state.has_official_scan_failed());
@@ -242,7 +244,7 @@ fn test_has_official_scan_failed_with_combined_failure() {
 
 #[test]
 fn test_scan_failure_marker_constants() {
-    use par_tui::io::terminal::{OFFICIAL_SCAN_FAILURE_MARKER, AUR_SCAN_FAILURE_MARKER};
+    use par_tui::io::terminal::{AUR_SCAN_FAILURE_MARKER, OFFICIAL_SCAN_FAILURE_MARKER};
 
     // Verify constants are what we expect
     assert_eq!(OFFICIAL_SCAN_FAILURE_MARKER, "Official");
@@ -254,19 +256,19 @@ fn test_scan_failure_marker_constants() {
 #[test]
 fn test_set_dependency_conflicts_shows_modal() {
     use par_tui::core::dependency::DependencyConflict;
-    
+
     let packages = vec![make_test_package("pkg1", PackageRepository::Official)];
     let mut state = AppState::new(packages, &[]);
-    
+
     assert!(!state.show_dependency_warning);
-    
+
     let conflicts = vec![DependencyConflict {
         ignored_package: "glibc".to_string(),
         required_by: vec!["systemd".to_string()],
     }];
-    
+
     state.set_dependency_conflicts(conflicts);
-    
+
     assert!(state.show_dependency_warning);
     assert_eq!(state.dependency_conflicts.len(), 1);
 }
@@ -275,12 +277,12 @@ fn test_set_dependency_conflicts_shows_modal() {
 fn test_toggle_dependency_warning() {
     let packages = vec![make_test_package("pkg1", PackageRepository::Official)];
     let mut state = AppState::new(packages, &[]);
-    
+
     assert!(!state.show_dependency_warning);
-    
+
     state.toggle_dependency_warning();
     assert!(state.show_dependency_warning);
-    
+
     state.toggle_dependency_warning();
     assert!(!state.show_dependency_warning);
 }
@@ -288,39 +290,39 @@ fn test_toggle_dependency_warning() {
 #[test]
 fn test_has_conflicts() {
     use par_tui::core::dependency::DependencyConflict;
-    
+
     let packages = vec![make_test_package("pkg1", PackageRepository::Official)];
     let mut state = AppState::new(packages, &[]);
-    
+
     assert!(!state.has_conflicts());
-    
+
     state.dependency_conflicts.push(DependencyConflict {
         ignored_package: "test".to_string(),
         required_by: vec!["dep".to_string()],
     });
-    
+
     assert!(state.has_conflicts());
 }
 
 #[test]
 fn test_pending_action_lifecycle() {
     use par_tui::ui::app::UIEvent;
-    
+
     let packages = vec![make_test_package("pkg1", PackageRepository::Official)];
     let mut state = AppState::new(packages, &[]);
-    
+
     // Initially None
     assert!(state.pending_action.is_none());
-    
+
     // Set action
     state.pending_action = Some(UIEvent::UpdateEntireSystem);
     assert!(state.pending_action.is_some());
-    
+
     // Take consumes it
     let action = state.pending_action.take();
     assert!(matches!(action, Some(UIEvent::UpdateEntireSystem)));
     assert!(state.pending_action.is_none());
-    
+
     // Clear sets to None
     state.pending_action = Some(UIEvent::UpdateOfficialOnly);
     state.pending_action = None;
@@ -331,9 +333,9 @@ fn test_pending_action_lifecycle() {
 fn test_reverse_deps_cache() {
     let packages = vec![make_test_package("pkg1", PackageRepository::Official)];
     let mut state = AppState::new(packages, &[]);
-    
+
     let mut call_count = 0;
-    
+
     // First call: cache miss, fetch called
     let (deps1, err1) = state.get_or_fetch_required_by("glibc", || {
         call_count += 1;
@@ -342,16 +344,16 @@ fn test_reverse_deps_cache() {
     assert_eq!(call_count, 1);
     assert_eq!(deps1.len(), 2);
     assert!(err1.is_none());
-    
+
     // Second call: cache hit, fetch not called
     let (deps2, err2) = state.get_or_fetch_required_by("glibc", || {
         call_count += 1;
-        Ok(vec![])  // Should not be reached
+        Ok(vec![]) // Should not be reached
     });
     assert_eq!(call_count, 1); // No increment - cache was used
     assert_eq!(deps2.len(), 2);
     assert!(err2.is_none());
-    
+
     // Different package: cache miss again
     let (deps3, err3) = state.get_or_fetch_required_by("bash", || {
         call_count += 1;
@@ -366,18 +368,16 @@ fn test_reverse_deps_cache() {
 fn test_reverse_deps_cache_error_handling() {
     let packages = vec![make_test_package("pkg1", PackageRepository::Official)];
     let mut state = AppState::new(packages, &[]);
-    
+
     // Fetch error: not cached
-    let (deps1, err1) = state.get_or_fetch_required_by("nonexistent", || {
-        Err("Package not found".to_string())
-    });
+    let (deps1, err1) =
+        state.get_or_fetch_required_by("nonexistent", || Err("Package not found".to_string()));
     assert!(deps1.is_empty());
     assert_eq!(err1, Some("Package not found".to_string()));
-    
+
     // Error result is not cached: fetch called again
-    let (deps2, err2) = state.get_or_fetch_required_by("nonexistent", || {
-        Err("Still not found".to_string())
-    });
+    let (deps2, err2) =
+        state.get_or_fetch_required_by("nonexistent", || Err("Still not found".to_string()));
     assert!(deps2.is_empty());
     assert_eq!(err2, Some("Still not found".to_string()));
 }
@@ -385,24 +385,23 @@ fn test_reverse_deps_cache_error_handling() {
 #[test]
 fn test_is_ready_states() {
     use par_tui::ui::app::LoadingState;
-    
+
     let packages = vec![make_test_package("pkg1", PackageRepository::Official)];
     let mut state = AppState::new(packages, &[]);
-    
+
     // Ready state
     state.loading_state = LoadingState::Ready;
     assert!(state.is_ready());
-    
+
     // NoUpdates state
     state.loading_state = LoadingState::NoUpdates;
     assert!(state.is_ready());
-    
+
     // Scanning state (not ready)
     state.loading_state = LoadingState::Scanning;
     assert!(!state.is_ready());
-    
+
     // Error state (not ready)
     state.loading_state = LoadingState::Error("test".to_string());
     assert!(!state.is_ready());
 }
-


### PR DESCRIPTION
## Changes
- Implement dependency conflict detection for ignored packages
- Add dynamic modal sizing for warnings
- Prevent config reset on quit during scan
- Quality improvements for dependency checks

## Related commits
- ff36338: Fix config reset on quit during scan
- 648f581: Enhance dynamic sizing for dependency warning modal
- 454ca11: Dynamic modal sizing for conflicts
- 6c761fe: Quality improvements for dependency checks
- f5d2237: Fix critical dependency check issues